### PR TITLE
Changed the iOS deployment target from 9.0 to 7.0 so that its compatible with the default setting for react-native projects. 

### DIFF
--- a/ios/RNNetworkInfo.xcodeproj/project.pbxproj
+++ b/ios/RNNetworkInfo.xcodeproj/project.pbxproj
@@ -161,7 +161,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -202,7 +202,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
Changed the iOS deployment target from 9.0 to 7.0 so that its compatible with the default setting for react-native projects.  It removes this build warning: libRNNetworkInfo.a(RNNetworkInfo.o)) was built for newer iOS version (8.4) than being linked (7.0)