### PR TITLE
Update version string, add author and tag to source.

### DIFF
--- a/react-native-network-info.podspec
+++ b/react-native-network-info.podspec
@@ -1,14 +1,16 @@
 Pod::Spec.new do |s|
   s.name         = "react-native-network-info"
-  s.version      = "0.1.1"
+  s.version      = "0.2.1"
   s.summary      = "Get local network information"
 
   s.homepage     = "https://github.com/pusherman/react-native-network-info"
+  s.author       = "Corey Wilson"
 
   s.license      = "MIT"
   s.platform     = :ios, "8.0"
 
-  s.source       = { :git => "https://github.com/pusherman/react-native-network-info" }
+
+  s.source       = { :git => "https://github.com/pusherman/react-native-network-info", :tag => "v#{s.version.to_s}" }
 
   s.source_files  = "ios/*.{h,m}"
 


### PR DESCRIPTION
This ensures that the podspec is usable for cocoapods 1.0+