### PR TITLE
removed the old and explicit version of the RN dependency.  this will prevent the parent project from downloading multiple versions of the RN library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,5 +27,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:0.11.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
removed the old and explicit version of the RN dependency.  this will prevent the parent project from downloading multiple versions of the RN library