### PR TITLE
specifying package name on link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ yarn add react-native-network-info
 
 ### Linking the library
 
-`react-native link`
+`react-native link react-native-network-info`
 
 ## Usage
 


### PR DESCRIPTION
safer to specify package name to avoid unwanted side effects