### PR TITLE
Fix: intellij-core not found issue #65

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-network-info",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Get local network information",
   "main": "NetworkInfo.js",
   "types": "NetworkInfo.d.ts",


### PR DESCRIPTION
Fix: https://stackoverflow.com/a/52952806

> Could not resolve all artifacts for configuration ':react-native-network-info:classpath'.
> Could not find intellij-core.jar (com.android.tools.external.com-intellij:intellij-core:26.0.1).

Solves #65 