### PR TITLE
fixbug on iPhoneX+

### DIFF
--- a/ios/RNNetworkInfo.h
+++ b/ios/RNNetworkInfo.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <React/RCTBridge.h>
+#import <React/RCTBridgeModule.h>
 
 @interface RNNetworkInfo : NSObject<RCTBridgeModule>
 


### PR DESCRIPTION
on iPhoneXR, call NetworkInfo.getSSID or other properties, will throw cannot read property 'getSSID' of undefined, so change '#import <React/RCTBridge.h>' to  '#import <React/RCTBridgeModule.h>`' resolve this problem