### PR TITLE
Change compile to implementation in Gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,5 +25,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
This is required due to changes in Android Studio.

```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```