### PR TITLE
Add support for tvOS and add getSubnet()

### DIFF
--- a/NetworkInfo.d.ts
+++ b/NetworkInfo.d.ts
@@ -4,5 +4,5 @@ export namespace NetworkInfo {
   function getBroadcast(): Promise<string | null>;
   function getIPAddress(): Promise<string | null>;
   function getIPV4Address(): Promise<string | null>;
-  function getSubnet(): Promise<Array<string> | null>;
+  function getSubnet(): Promise<string | null>;
 }

--- a/NetworkInfo.d.ts
+++ b/NetworkInfo.d.ts
@@ -4,4 +4,5 @@ export namespace NetworkInfo {
   function getBroadcast(): Promise<string | null>;
   function getIPAddress(): Promise<string | null>;
   function getIPV4Address(): Promise<string | null>;
+  function getSubnet(): Promise<Array<string> | null>;
 }

--- a/NetworkInfo.js
+++ b/NetworkInfo.js
@@ -23,6 +23,10 @@ const NetworkInfo = {
   async getIPV4Address() {
     return await RNNetworkInfo.getIPV4Address();
   }
+
+  async getSubnet() {
+    return await RNNetworkInfo.getSubnet();
+  }
 };
 
 module.exports = { NetworkInfo };

--- a/NetworkInfo.js
+++ b/NetworkInfo.js
@@ -1,6 +1,6 @@
-'use strict';
+"use strict";
 
-import { NativeModules } from 'react-native';
+import { NativeModules } from "react-native";
 const { RNNetworkInfo } = NativeModules;
 
 const NetworkInfo = {
@@ -22,7 +22,7 @@ const NetworkInfo = {
 
   async getIPV4Address() {
     return await RNNetworkInfo.getIPV4Address();
-  }
+  },
 
   async getSubnet() {
     return await RNNetworkInfo.getSubnet();

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Version 2+ requires RN 0.40 - RN 0.46
 ```javascript
 npm install react-native-network-info --save
 ```
+
 or
 
 ```javascript
@@ -25,25 +26,26 @@ yarn add react-native-network-info
 ## Usage
 
 ```javascript
-
-import { NetworkInfo } from 'react-native-network-info';
+import { NetworkInfo } from "react-native-network-info";
 
 // Get Local IP
 const ipAddress = await NetworkInfo.getIPAddress();
 
 // Get IPv4 IP
-const ipv4Address = await NetworkInfo.getIPV4Address()
+const ipv4Address = await NetworkInfo.getIPV4Address();
 
 // Get Broadcast
-const broadcast = await NetworkInfo.getBroadcast()
+const broadcast = await NetworkInfo.getBroadcast();
 
 // Get SSID
-const ssid = await NetworkInfo.getSSID()
+const ssid = await NetworkInfo.getSSID();
 
 // Get BSSID
-const bssid = await NetworkInfo.getBSSID()
-```
+const bssid = await NetworkInfo.getBSSID();
 
+// Get Subnet
+const subnet = await NetworkInfo.getSubnet();
+```
 
 ### Manually Linking the Library
 
@@ -62,51 +64,55 @@ Run your project (Cmd+R)
 ### `Android`
 
 1. Add the following lines to `android/settings.gradle`:
-    ```gradle
-    include ':react-native-network-info'
-    project(':react-native-network-info').projectDir = new File(settingsDir, '../node_modules/react-native-network-info/android')
-    ```
+
+   ```gradle
+   include ':react-native-network-info'
+   project(':react-native-network-info').projectDir = new File(settingsDir, '../node_modules/react-native-network-info/android')
+   ```
 
 2. Update the android build tools version to `2.2.+` in `android/build.gradle`:
-    ```gradle
-    buildscript {
-        ...
-        dependencies {
-            classpath 'com.android.tools.build:gradle:2.2.+' // <- USE 2.2.+ version
-        }
-        ...
-    }
-    ...
-    ```
+   ```gradle
+   buildscript {
+       ...
+       dependencies {
+           classpath 'com.android.tools.build:gradle:2.2.+' // <- USE 2.2.+ version
+       }
+       ...
+   }
+   ...
+   ```
 3. Update the gradle version to `2.14.1` in `android/gradle/wrapper/gradle-wrapper.properties`:
-    ```
-    ...
-    distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
-    ```
+
+   ```
+   ...
+   distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+   ```
 
 4. Add the compile line to the dependencies in `android/app/build.gradle`:
-    ```gradle
-    dependencies {
-        ...
-        compile project(':react-native-network-info')
-    }
-    ```
+
+   ```gradle
+   dependencies {
+       ...
+       compile project(':react-native-network-info')
+   }
+   ```
 
 5. Add the import and link the package in `MainApplication.java`:
-    ```java
-    import com.pusherman.networkinfo.RNNetworkInfoPackage; // <-- add this import
 
-    public class MainApplication extends Application implements ReactApplication {
-        @Override
-        protected List<ReactPackage> getPackages() {
-            return Arrays.<ReactPackage>asList(
-                new MainReactPackage(),
-                new RNNetworkInfoPackage() // <-- add this line
-            );
-        }
-    }
-    ```
+   ```java
+   import com.pusherman.networkinfo.RNNetworkInfoPackage; // <-- add this import
 
+   public class MainApplication extends Application implements ReactApplication {
+       @Override
+       protected List<ReactPackage> getPackages() {
+           return Arrays.<ReactPackage>asList(
+               new MainReactPackage(),
+               new RNNetworkInfoPackage() // <-- add this line
+           );
+       }
+   }
+   ```
 
 ## Dev Notes
+
 Notes on how this package was made can be [found here](https://eastcodes.com/packaging-and-sharing-react-native-modules "Packaging and Sharing React Native Modules").

--- a/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
+++ b/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Arrays;
 import java.util.List;
+import java.net.Inet6Address;
 
 public class RNNetworkInfo extends ReactContextBaseJavaModule {
     WifiManager wifi;

--- a/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
+++ b/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
@@ -183,7 +183,7 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                         }
                     }
                 } catch (Exception e) {
-                    promise.resolve(null);
+                    promise.resolve("0.0.0.0");
                 }
             }
         }).start();

--- a/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
+++ b/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
@@ -21,20 +21,18 @@ import java.util.Enumeration;
 import java.util.Arrays;
 import java.util.List;
 
-
 public class RNNetworkInfo extends ReactContextBaseJavaModule {
     WifiManager wifi;
 
     public static final String TAG = "RNNetworkInfo";
 
-    public static List<String> DSLITE_LIST = Arrays.asList("192.0.0.0", "192.0.0.1", "192.0.0.2", "192.0.0.3", "192.0.0.4", "192.0.0.5", "192.0.0.6", "192.0.0.7");
-
+    public static List<String> DSLITE_LIST = Arrays.asList("192.0.0.0", "192.0.0.1", "192.0.0.2", "192.0.0.3",
+            "192.0.0.4", "192.0.0.5", "192.0.0.6", "192.0.0.7");
 
     public RNNetworkInfo(ReactApplicationContext reactContext) {
         super(reactContext);
 
-        wifi = (WifiManager) reactContext.getApplicationContext()
-                .getSystemService(Context.WIFI_SERVICE);
+        wifi = (WifiManager) reactContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
     }
 
     @Override
@@ -96,7 +94,8 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                     String ipAddress = null;
 
                     for (InterfaceAddress address : getInetAddresses()) {
-                        if (!address.getAddress().isLoopbackAddress()/*address.getAddress().toString().equalsIgnoreCase(ip)*/) {
+                        if (!address.getAddress()
+                                .isLoopbackAddress()/* address.getAddress().toString().equalsIgnoreCase(ip) */) {
                             ipAddress = address.getBroadcast().toString();
                         }
                     }
@@ -160,19 +159,67 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
         }).start();
     }
 
+    @ReactMethod
+    public void getSubnet(final Promise promise) throws Exception {
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+
+                    while (interfaces.hasMoreElements()) {
+                        NetworkInterface iface = interfaces.nextElement();
+                        if (iface.isLoopback() || !iface.isUp())
+                            continue;
+
+                        Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                        for (InterfaceAddress address : iface.getInterfaceAddresses()) {
+
+                            InetAddress addr = addresses.nextElement();
+                            if (addr instanceof Inet6Address)
+                                continue;
+
+                            promise.resolve(intToIP(address.getNetworkPrefixLength()));
+                            return;
+                        }
+                    }
+                } catch (Exception e) {
+                    promise.resolve(null);
+                }
+            }
+        }).start();
+    }
+
+    private String intToIP(int ip) {
+        String[] finl = { "", "", "", "" };
+        int k = 1;
+
+        for (int i = 0; i < 4; i++) {
+            for (int j = 0; j < 8; j++) {
+                if (k <= ip) {
+                    finl[i] += "1";
+                } else {
+                    finl[i] += "0";
+                }
+                k++;
+
+            }
+        }
+        return Integer.parseInt(finl[0], 2) + "." + Integer.parseInt(finl[1], 2) + "." + Integer.parseInt(finl[2], 2)
+                + "." + Integer.parseInt(finl[3], 2);
+    }
 
     private Boolean inDSLITERange(String ip) {
         // Fixes issue https://github.com/pusherman/react-native-network-info/issues/43
-        // Based on comment https://github.com/pusherman/react-native-network-info/issues/43#issuecomment-358360692
+        // Based on comment
+        // https://github.com/pusherman/react-native-network-info/issues/43#issuecomment-358360692
         // added this check in getIPAddress and getIPV4Address
         return RNNetworkInfo.DSLITE_LIST.contains(ip);
     }
 
-
     private List<InterfaceAddress> getInetAddresses() {
         List<InterfaceAddress> addresses = new ArrayList<>();
         try {
-            for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements(); ) {
+            for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
                 NetworkInterface intf = en.nextElement();
 
                 for (InterfaceAddress interface_address : intf.getInterfaceAddresses()) {

--- a/ios/RNNetworkInfo.m
+++ b/ios/RNNetworkInfo.m
@@ -11,6 +11,7 @@
 #import <ifaddrs.h>
 #import <arpa/inet.h>
 #include <net/if.h>
+#include <TargetConditionals.h>
 
 #define IOS_CELLULAR    @"pdp_ip0"
 #define IOS_WIFI        @"en0"
@@ -24,6 +25,7 @@
 
 RCT_EXPORT_MODULE();
 
+#if TARGET_OS_IOS
 RCT_EXPORT_METHOD(getSSID:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -46,7 +48,9 @@ RCT_EXPORT_METHOD(getSSID:(RCTPromiseResolveBlock)resolve
         resolve(NULL);
     }
 }
+#endif
 
+#if TARGET_OS_IOS
 RCT_EXPORT_METHOD(getBSSID:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -68,6 +72,7 @@ RCT_EXPORT_METHOD(getBSSID:(RCTPromiseResolveBlock)resolve
         resolve(NULL);
     }
 }
+#endif
 
 RCT_EXPORT_METHOD(getBroadcast:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/RNNetworkInfo.m
+++ b/ios/RNNetworkInfo.m
@@ -172,38 +172,40 @@ RCT_EXPORT_METHOD(getIPV4Address:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getSubnet:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSString *address = @"error";
-    NSString *netmask = @"error";
-    struct ifaddrs *interfaces = NULL;
-    struct ifaddrs *temp_addr = NULL;
-    
-    int success = 0;
-    
-    // retrieve the current interfaces - returns 0 on success
-    success = getifaddrs(&interfaces);
-    if (success == 0)
-    {
-        temp_addr = interfaces;
+    @try {
+        NSString *netmask = @"error";
+        struct ifaddrs *interfaces = NULL;
+        struct ifaddrs *temp_addr = NULL;
         
-        while(temp_addr != NULL)
+        int success = 0;
+        
+        // retrieve the current interfaces - returns 0 on success
+        success = getifaddrs(&interfaces);
+        if (success == 0)
         {
-            // check if interface is en0 which is the wifi connection on the iPhone
-            if(temp_addr->ifa_addr->sa_family == AF_INET)
-            {
-                if([@(temp_addr->ifa_name) isEqualToString:@"en0"])
-                {
-                    address = @(inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_addr)->sin_addr));
-                    netmask = @(inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_netmask)->sin_addr));
-                }
-            }
+            temp_addr = interfaces;
             
-            temp_addr = temp_addr->ifa_next;
+            while(temp_addr != NULL)
+            {
+                // check if interface is en0 which is the wifi connection on the iPhone
+                if(temp_addr->ifa_addr->sa_family == AF_INET)
+                {
+                    if([@(temp_addr->ifa_name) isEqualToString:@"en0"])
+                    {
+                        netmask = @(inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_netmask)->sin_addr));
+                    }
+                }
+                
+                temp_addr = temp_addr->ifa_next;
+            }
         }
+        freeifaddrs(interfaces);
+        
+        NSString *addressToReturn = netmask ? netmask : @"0.0.0.0";
+        resolve(addressToReturn);
+    } @catch (NSException *exception) {
+        resolve(NULL);
     }
-    freeifaddrs(interfaces);
-    
-    NSArray *nativeModuleList = @[netmask];
-    resolve(nativeModuleList);
 }
 
 - (NSDictionary *)getAllIPAddresses

--- a/ios/RNNetworkInfo.xcodeproj/project.pbxproj
+++ b/ios/RNNetworkInfo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		045BEB401B52EA6A0013C1B9 /* RNNetworkInfo.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 045BEB3F1B52EA6A0013C1B9 /* RNNetworkInfo.h */; };
 		045BEB421B52EA6A0013C1B9 /* RNNetworkInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 045BEB411B52EA6A0013C1B9 /* RNNetworkInfo.m */; };
+		A051C2CC22B1C13E001E1191 /* RNNetworkInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 045BEB411B52EA6A0013C1B9 /* RNNetworkInfo.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -22,16 +23,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A051C2C122B1C080001E1191 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		045BEB3C1B52EA6A0013C1B9 /* libRNNetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNNetworkInfo.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		045BEB3F1B52EA6A0013C1B9 /* RNNetworkInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNetworkInfo.h; sourceTree = "<group>"; };
 		045BEB411B52EA6A0013C1B9 /* RNNetworkInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNetworkInfo.m; sourceTree = "<group>"; };
+		A051C2C322B1C080001E1191 /* libRNNetworkInfo-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libRNNetworkInfo-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		045BEB391B52EA6A0013C1B9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A051C2C022B1C080001E1191 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -54,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				045BEB3C1B52EA6A0013C1B9 /* libRNNetworkInfo.a */,
+				A051C2C322B1C080001E1191 /* libRNNetworkInfo-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -78,6 +97,23 @@
 			productReference = 045BEB3C1B52EA6A0013C1B9 /* libRNNetworkInfo.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		A051C2C222B1C080001E1191 /* RNNetworkInfo-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A051C2CB22B1C080001E1191 /* Build configuration list for PBXNativeTarget "RNNetworkInfo-tvOS" */;
+			buildPhases = (
+				A051C2BF22B1C080001E1191 /* Sources */,
+				A051C2C022B1C080001E1191 /* Frameworks */,
+				A051C2C122B1C080001E1191 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RNNetworkInfo-tvOS";
+			productName = "RNNetworkInfo-tvOS";
+			productReference = A051C2C322B1C080001E1191 /* libRNNetworkInfo-tvOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -90,6 +126,11 @@
 					045BEB3B1B52EA6A0013C1B9 = {
 						CreatedOnToolsVersion = 6.4;
 					};
+					A051C2C222B1C080001E1191 = {
+						CreatedOnToolsVersion = 10.2.1;
+						DevelopmentTeam = A7LNG47RWM;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 045BEB371B52EA6A0013C1B9 /* Build configuration list for PBXProject "RNNetworkInfo" */;
@@ -97,6 +138,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 045BEB331B52EA6A0013C1B9;
@@ -105,6 +147,7 @@
 			projectRoot = "";
 			targets = (
 				045BEB3B1B52EA6A0013C1B9 /* RNNetworkInfo */,
+				A051C2C222B1C080001E1191 /* RNNetworkInfo-tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -115,6 +158,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				045BEB421B52EA6A0013C1B9 /* RNNetworkInfo.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A051C2BF22B1C080001E1191 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A051C2CC22B1C13E001E1191 /* RNNetworkInfo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,6 +284,73 @@
 			};
 			name = Release;
 		};
+		A051C2C922B1C080001E1191 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = A7LNG47RWM;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 12.2;
+			};
+			name = Debug;
+		};
+		A051C2CA22B1C080001E1191 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = A7LNG47RWM;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 12.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -250,6 +368,15 @@
 			buildConfigurations = (
 				045BEB511B52EA6B0013C1B9 /* Debug */,
 				045BEB521B52EA6B0013C1B9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A051C2CB22B1C080001E1191 /* Build configuration list for PBXNativeTarget "RNNetworkInfo-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A051C2C922B1C080001E1191 /* Debug */,
+				A051C2CA22B1C080001E1191 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Adding support for tvOS as it is required in our tvOS project.

Adding a new getSubnet() function taken from another library. Credits to the `get-subnet-mask` library. 

PS: Prettier accidentally formatted some files in a specific way, please let me know if this might be an issue so I can resolve it.