### PR TITLE
Add method to read WiFi frequency for Android

### DIFF
--- a/NetworkInfo.d.ts
+++ b/NetworkInfo.d.ts
@@ -5,4 +5,5 @@ export namespace NetworkInfo {
   function getIPAddress(): Promise<string | null>;
   function getIPV4Address(): Promise<string | null>;
   function getSubnet(): Promise<string | null>;
+  function getFrequency(): Promise<number | null>;
 }

--- a/NetworkInfo.js
+++ b/NetworkInfo.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { NativeModules } from "react-native";
+import { NativeModules, Platform } from "react-native";
 const { RNNetworkInfo } = NativeModules;
 
 const NetworkInfo = {
@@ -26,6 +26,13 @@ const NetworkInfo = {
 
   async getSubnet() {
     return await RNNetworkInfo.getSubnet();
+  },
+
+  async getFrequency() {
+    if (Platform.OS !== 'android') {
+      return null;
+    }
+    return await RNNetworkInfo.getFrequency();
   }
 };
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ const bssid = await NetworkInfo.getBSSID();
 
 // Get Subnet
 const subnet = await NetworkInfo.getSubnet();
+
+// Get frequency (supported only for Android)
+const frequency = await NetworkInfo.getFrequency();
 ```
 
 ### Manually Linking the Library

--- a/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
+++ b/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
@@ -190,6 +190,21 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
         }).start();
     }
 
+    @ReactMethod
+    public void getFrequency(final Promise promise) throws Exception {
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    WifiInfo info = wifi.getConnectionInfo();
+                    final float frequency = info.getFrequency();
+                    promise.resolve(frequency);
+                } catch (Exception e) {
+                    promise.resolve(null);
+                }
+            }
+        }).start();
+    }
+
     private String intToIP(int ip) {
         String[] finl = { "", "", "", "" };
         int k = 1;


### PR DESCRIPTION
Added a `getFrequency` method for Android. [Android SDK method description](https://developer.android.com/reference/android/net/wifi/WifiInfo.html#getFrequency()).
Example: for 2.4 GHz networks, the method will return `2457`.

Unfortunately, iOS does not allow to access a connected WiFi frequency, so for iOS, the method returns `null`.

The pull request contains new Java method, new JavaScript method, TypeScript method definition and README update.