### PR TITLE
throw error to JS and log it

### DIFF
--- a/NetworkInfo.d.ts
+++ b/NetworkInfo.d.ts
@@ -1,10 +1,10 @@
 export namespace NetworkInfo {
-  function getSSID(): Promise<string | null>;
-  function getBSSID(): Promise<string | null>;
-  function getBroadcast(): Promise<string | null>;
-  function getIPAddress(): Promise<string | null>;
-  function getIPV4Address(): Promise<string | null>;
-  function getSubnet(): Promise<string | null>;
-  function getGatewayIPAddress(): Promise<string | null>;
-  function getFrequency(): Promise<number | null>;
+  function getSSID(fallback: any): Promise<string | null>;
+  function getBSSID(fallback: any): Promise<string | null>;
+  function getBroadcast(fallback: any): Promise<string | null>;
+  function getIPAddress(fallback: any): Promise<string | null>;
+  function getIPV4Address(fallback: any): Promise<string | null>;
+  function getSubnet(fallback: any): Promise<string | null>;
+  function getGatewayIPAddress(fallback: any): Promise<string | null>;
+  function getFrequency(fallback: any): Promise<number | null>;
 }

--- a/NetworkInfo.js
+++ b/NetworkInfo.js
@@ -3,46 +3,56 @@
 import { NativeModules, Platform } from "react-native";
 const { RNNetworkInfo } = NativeModules;
 
+async function handleError(callback, fallback = null) {
+  try {
+    return await callback();
+  } catch (error) {
+    if (__DEV__) console.log(error);
+
+    return fallback;
+  }
+}
+
 const NetworkInfo = {
-  async getSSID() {
-    return await RNNetworkInfo.getSSID();
+  async getSSID(fallback) {
+    return await handleError(RNNetworkInfo.getSSID, fallback);
   },
 
-  async getBSSID() {
-    return await RNNetworkInfo.getBSSID();
+  async getBSSID(fallback) {
+    return await handleError(RNNetworkInfo.getBSSID, fallback);
   },
 
-  async getBroadcast() {
-    return await RNNetworkInfo.getBroadcast();
+  async getBroadcast(fallback) {
+    return await handleError(RNNetworkInfo.getBroadcast, fallback);
   },
 
-  async getIPAddress() {
-    return await RNNetworkInfo.getIPAddress();
+  async getIPAddress(fallback) {
+    return await handleError(RNNetworkInfo.getIPAddress, fallback);
   },
 
-  async getIPV4Address() {
-    const wifiIP = await RNNetworkInfo.getWIFIIPV4Address();
-    if (wifiIP && wifiIP !== '0.0.0.0') {
+  async getIPV4Address(fallback) {
+    const wifiIP = await handleError(RNNetworkInfo.getWIFIIPV4Address);
+    if (wifiIP) {
       return wifiIP;
     }
-    
-    return await RNNetworkInfo.getIPV4Address();
+
+    return await handleError(RNNetworkInfo.getIPV4Address, fallback);
   },
 
-  async getGatewayIPAddress() {
-    return await RNNetworkInfo.getGatewayIPAddress();
+  async getGatewayIPAddress(fallback) {
+    return await handleError(RNNetworkInfo.getGatewayIPAddress, fallback);
   },
 
-  async getSubnet() {
-    return await RNNetworkInfo.getSubnet();
+  async getSubnet(fallback) {
+    return await handleError(RNNetworkInfo.getSubnet, fallback);
   },
 
-  async getFrequency() {
+  async getFrequency(fallback) {
     if (Platform.OS !== 'android') {
-      return null;
+      return fallback;
     }
-    return await RNNetworkInfo.getFrequency();
-  }
+    return await handleError(RNNetworkInfo.getFrequency, fallback);
+  },
 };
 
 module.exports = { NetworkInfo };

--- a/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
+++ b/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.net.DhcpInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
+
+import androidx.annotation.NonNull;
+
 import android.net.wifi.SupplicantState;
 import android.util.Log;
 
@@ -57,10 +60,12 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                         if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
                             ssid = ssid.substring(1, ssid.length() - 1);
                         }
+                    } else {
+                        throw new Exception("The Supplicant State has not been completed");
                     }
                     promise.resolve(ssid);
                 } catch (Exception e) {
-                    promise.resolve(null);
+                    promise.reject(e);
                 }
 
             }
@@ -77,11 +82,13 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                     // https://stackoverflow.com/a/34848930/5732760
                     String bssid = null;
                     if (info.getSupplicantState() == SupplicantState.COMPLETED) {
-                        bssid = wifi.getConnectionInfo().getBSSID();
+                        bssid = info.getBSSID();
+                    } else {
+                        throw new Exception("The Supplicant State has not been completed");
                     }
                     promise.resolve(bssid);
                 } catch (Exception e) {
-                    promise.resolve(null);
+                    promise.reject(e);
                 }
 
             }
@@ -101,9 +108,12 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                             ipAddress = address.getBroadcast().toString();
                         }
                     }
+                    if (ipAddress == null) {
+                        throw new Exception("Broadcast address not found");
+                    }
                     promise.resolve(ipAddress);
                 } catch (Exception e) {
-                    promise.resolve(null);
+                    promise.reject(e);
                 }
 
             }
@@ -126,9 +136,12 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                             }
                         }
                     }
+                    if (ipAddress == null) {
+                        throw new Exception("IP address not found");
+                    }
                     promise.resolve(ipAddress);
                 } catch (Exception e) {
-                    promise.resolve(null);
+                    promise.reject(e);
                 }
 
             }
@@ -152,9 +165,12 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                             }
                         }
                     }
+                    if (ipAddress == null) {
+                        throw new Exception("IPV4 address not found");
+                    }
                     promise.resolve(ipAddress);
                 } catch (Exception e) {
-                    promise.resolve(null);
+                    promise.reject(e);
                 }
 
             }
@@ -176,7 +192,7 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                                                 (ipAddress >> 16 & 0xff), (ipAddress >> 24 & 0xff));
 		            promise.resolve(stringip);
                 }catch (Exception e) {
-                    promise.resolve(null);
+                    promise.reject(e);
                 }
             }
         }).start();
@@ -205,8 +221,9 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                             return;
                         }
                     }
+                    throw new Exception("Subnet not found");
                 } catch (Exception e) {
-                    promise.resolve("0.0.0.0");
+                    promise.reject(e);
                 }
             }
         }).start();
@@ -220,15 +237,15 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                     DhcpInfo dhcpInfo = wifi.getDhcpInfo();
                     int gatewayIPInt = dhcpInfo.gateway;
                     String gatewayIP = String.format(
-                      "%d.%d.%d.%d",
-                      ((gatewayIPInt) & 0xFF),
-                      ((gatewayIPInt >> 8 ) & 0xFF),
-                      ((gatewayIPInt >> 16) & 0xFF),
-                      ((gatewayIPInt >> 24) & 0xFF)
+                            "%d.%d.%d.%d",
+                            ((gatewayIPInt) & 0xFF),
+                            ((gatewayIPInt >> 8 ) & 0xFF),
+                            ((gatewayIPInt >> 16) & 0xFF),
+                            ((gatewayIPInt >> 24) & 0xFF)
                     );
                     promise.resolve(gatewayIP);
                 } catch (Exception e) {
-                    promise.resolve(null);
+                    promise.reject(e);
                 }
             }
         }).start();
@@ -243,7 +260,7 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                     final float frequency = info.getFrequency();
                     promise.resolve(frequency);
                 } catch (Exception e) {
-                    promise.resolve(null);
+                    promise.reject(e);
                 }
             }
         }).start();
@@ -270,7 +287,7 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
 
     private Boolean inDSLITERange(String ip) {
         // Fixes issue https://github.com/pusherman/react-native-network-info/issues/43
-        // Based on comment
+        // Based on comment 
         // https://github.com/pusherman/react-native-network-info/issues/43#issuecomment-358360692
         // added this check in getIPAddress and getIPV4Address
         return RNNetworkInfo.DSLITE_LIST.contains(ip);

--- a/ios/RNNetworkInfo.m
+++ b/ios/RNNetworkInfo.m
@@ -46,9 +46,17 @@ RCT_EXPORT_METHOD(getSSID:(RCTPromiseResolveBlock)resolve
                 break;
             }
         }
+        
+        if (SSID == NULL) {
+            NSException* exception = [NSException
+                                      exceptionWithName:@"SSIDNotFoundException"
+                                      reason:@"SSID Not Found"
+                                      userInfo:nil];
+            @throw exception;
+        }
         resolve(SSID);
     }@catch (NSException *exception) {
-        resolve(NULL);
+        reject(exception);
     }
 }
 #endif
@@ -70,9 +78,17 @@ RCT_EXPORT_METHOD(getBSSID:(RCTPromiseResolveBlock)resolve
                 CFRelease(networkDetails);
             }
         }
+        
+        if (BSSID == NULL) {
+            NSException* exception = [NSException
+                                      exceptionWithName:@"BSSIDNotFoundException"
+                                      reason:@"BSSID Not Found"
+                                      userInfo:nil];
+            @throw exception;
+        }
         resolve(BSSID);
     }@catch (NSException *exception) {
-        resolve(NULL);
+        reject(exception);
     }
 }
 #endif
@@ -111,11 +127,28 @@ RCT_EXPORT_METHOD(getBroadcast:(RCTPromiseResolveBlock)resolve
                 }
                 temp_addr = temp_addr->ifa_next;
             }
+        } else {
+            freeifaddrs(interfaces);
+
+            NSException* exception = [NSException
+                                      exceptionWithName:@"BroadcastNotFoundException"
+                                      reason:@"getifaddrs has been Not successful"
+                                      userInfo:nil];
+            @throw exception;
         }
+
         freeifaddrs(interfaces);
+
+        if (address == NULL) {
+            NSException* exception = [NSException
+                                      exceptionWithName:@"BroadcastNotFoundException"
+                                      reason:@"Broadcast Not Found"
+                                      userInfo:nil];
+            @throw exception;
+        }
         resolve(address);
     }@catch (NSException *exception) {
-        resolve(NULL);
+        reject(exception);
     }
 }
 
@@ -141,11 +174,28 @@ RCT_EXPORT_METHOD(getIPAddress:(RCTPromiseResolveBlock)resolve
                 }
                 temp_addr = temp_addr->ifa_next;
             }
+        } else {
+            freeifaddrs(interfaces);
+
+            NSException* exception = [NSException
+                                      exceptionWithName:@"IPAddressNotFoundException"
+                                      reason:@"getifaddrs has been Not successful"
+                                      userInfo:nil];
+            @throw exception;
         }
         freeifaddrs(interfaces);
+        
+        if (address == NULL) {
+            NSException* exception = [NSException
+                                      exceptionWithName:@"IPAddressNotFoundException"
+                                      reason:@"IPAddress Not Found"
+                                      userInfo:nil];
+            @throw exception;
+        }
+
         resolve(address);
     }@catch (NSException *exception) {
-        resolve(NULL);
+        reject(exception);
     }
 }
 
@@ -161,7 +211,7 @@ RCT_EXPORT_METHOD(getGatewayIPAddress:(RCTPromiseResolveBlock)resolve
     	}
         resolve(ipString);
     }@catch (NSException *exception) {
-        resolve(NULL);
+        reject(exception);
     }
 }
 
@@ -179,10 +229,18 @@ RCT_EXPORT_METHOD(getIPV4Address:(RCTPromiseResolveBlock)resolve
              address = addresses[key];
              if(address) *stop = YES;
          } ];
-        NSString *addressToReturn = address ? address : @"0.0.0.0";
-        resolve(addressToReturn);
+        
+        if (address) {
+            resolve(address);
+        }
+            NSException* exception = [NSException
+                                      exceptionWithName:@"IPV4AddressNotFoundException"
+                                      reason:@"IPV4Address Not Found"
+                                      userInfo:nil];
+            @throw exception;
+        }
     }@catch (NSException *exception) {
-        resolve(NULL);
+        reject(exception);
     }
 }
 
@@ -204,10 +262,17 @@ RCT_EXPORT_METHOD(getWIFIIPV4Address:(RCTPromiseResolveBlock)resolve
              address = addresses[key];
              if(address) *stop = YES;
          } ];
-        NSString *addressToReturn = address ? address : @"0.0.0.0";
-        resolve(addressToReturn);
+         if(address){
+            resolve(address);
+         } else {
+            NSException* exception = [NSException
+                                      exceptionWithName:@"WIFIIPV4AddressNotFoundException"
+                                      reason:@"WIFIIPV4Address Not Found"
+                                      userInfo:nil];
+            @throw exception;
+         }
     }@catch (NSException *exception) {
-        resolve(NULL);
+        reject(exception);
     }
 }
 
@@ -215,7 +280,7 @@ RCT_EXPORT_METHOD(getSubnet:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     @try {
-        NSString *netmask = @"error";
+        NSString *netmask = NULL;
         struct ifaddrs *interfaces = NULL;
         struct ifaddrs *temp_addr = NULL;
         
@@ -242,11 +307,18 @@ RCT_EXPORT_METHOD(getSubnet:(RCTPromiseResolveBlock)resolve
             }
         }
         freeifaddrs(interfaces);
-        
-        NSString *addressToReturn = netmask ? netmask : @"0.0.0.0";
-        resolve(addressToReturn);
+
+        if (netmask == NULL) {
+            NSException* exception = [NSException
+                                      exceptionWithName:@"IPV4AddressNotFoundException"
+                                      reason:@"IPV4Address Not Found"
+                                      userInfo:nil];
+            @throw exception;
+        }
+
+        resolve(netmask);
     } @catch (NSException *exception) {
-        resolve(NULL);
+        reject(exception);
     }
 }
 


### PR DESCRIPTION
In this repo, we have a few issues and Often caused by native errors which the user couldn't see that. 

However, I give error from native to JS and log it in console, then return fallback.

 Now any user can see native errors in the log, understand and solve it.

I had tested this code in a project for android, and that's work pretty, but I am not sure about ios, please test it.

Great regards 
Hossein Mohammadi