### PR TITLE
fix broadcast adress nullpointer exception on Android.

### DIFF
--- a/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
+++ b/android/src/main/java/com/pusherman/networkinfo/RNNetworkInfo.java
@@ -96,9 +96,11 @@ public class RNNetworkInfo extends ReactContextBaseJavaModule {
                     String ipAddress = null;
 
                     for (InterfaceAddress address : getInetAddresses()) {
-                        if (!address.getAddress()
-                                .isLoopbackAddress()/* address.getAddress().toString().equalsIgnoreCase(ip) */) {
-                            ipAddress = address.getBroadcast().toString();
+                        if (!address.getAddress().isLoopbackAddress()/*address.getAddress().toString().equalsIgnoreCase(ip)*/) {
+                            InetAddress broadCast = address.getBroadcast();
+                            if (broadCast != null){
+                                ipAddress = broadCast.toString();
+                            }
                         }
                     }
                     promise.resolve(ipAddress);


### PR DESCRIPTION
Fix Issue "getBroadcast() could be null in android on some interfaces #59"

Just added a null check.